### PR TITLE
crackling: Add flag for face unlock

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -149,5 +149,8 @@ PRODUCT_COPY_FILES += \
     $(LOCAL_PATH)/wifi/WCNSS_cfg.dat:$(TARGET_COPY_OUT_VENDOR)/firmware/wlan/prima/WCNSS_cfg.dat \
     $(LOCAL_PATH)/wifi/WCNSS_qcom_wlan_nv.bin:$(TARGET_COPY_OUT_VENDOR)/firmware/wlan/prima/WCNSS_qcom_wlan_nv.bin
 
+# Face unlock
+TARGET_FACE_UNLOCK_SUPPORTED := true
+
 # Call the proprietary setup
 $(call inherit-product, vendor/wileyfox/crackling/crackling-vendor.mk)


### PR DESCRIPTION
This will help people building a ROM with face unlock package included in sources like crDroid 7 for them to add face unlock right out of the box. I personally got to use this flag in this style only for my unofficial build of Resurrection Remix 8.6.4 and it works real fast.

I need to thank @TeGaX for giving me that flag on Seed trees so I could use it.